### PR TITLE
implement task clarification logic in clarify.js

### DIFF
--- a/backend/routes/clarify.js
+++ b/backend/routes/clarify.js
@@ -7,9 +7,85 @@ router.post("/", async (req, res) => {
   try {
     const { task } = req.body;
 
-    res.json({ message: "Task clarification endpoint" });
+    if (!task) {
+      return res.status(400).json({ error: "Task is required" });
+    }
+
+    // calling the query function - DeepSeek model
+    const aiResponse = await query({
+      messages: [
+        {
+          role: "system",
+          content:
+            "Return ONLY a JSON object with 2-4 relevant fields for scheduling/executing this task. ALLOWED KEYS ONLY: 'tm' (time needed), 'bt' (best time), 'pre' (prerequisites), 'nrg' (energy level), 'rem' (reminder), 'loc' (location), 'tl' (tools). Values must be concise strings. Example: {\"tm\":\"30 minutes\",\"bt\":\"Morning\",\"nrg\":\"High\"}. NO other keys allowed. NO explanation text. ONLY the JSON object.",
+        },
+        {
+          role: "user",
+          content: `Generate metadata JSON for: "${task}"`,
+        },
+      ],
+      model: "deepseek-ai/DeepSeek-V3:novita",
+      max_tokens: 100,
+      temperature: 0.3,
+    });
+
+    // tm   = time needed
+    // bt   = best time
+    // pre  = prerequisites
+    // nrg  = energy level
+    // rem  = reminder
+    // loc  = location
+    // tl   = tools
+
+    // parse the AI's response
+    let aiMessage = aiResponse.choices?.[0]?.message?.content;
+
+    // strip markdown code blocks if present
+    aiMessage = aiMessage
+      .replace(/```json\n?/g, "")
+      .replace(/```\n?/g, "")
+      .trim();
+
+    console.log("Cleaned AI Response:", aiMessage);
+
+    let taskContext;
+    const allowedKeys = ["tm", "bt", "pre", "nrg", "rem", "loc", "tl"];
+
+    try {
+      taskContext = JSON.parse(aiMessage);
+
+      // validate only allowed keys are present
+      const keys = Object.keys(taskContext);
+      const invalidKeys = keys.filter(key => !allowedKeys.includes(key));
+
+      if (invalidKeys.length > 0) {
+        invalidKeys.forEach(key => delete taskContext[key]);
+      }
+
+      // ensure to  have at least 2 fields
+      if (Object.keys(taskContext).length < 2) {
+        throw new Error("Insufficient context fields");
+      }
+    } catch (e) {
+      // fallback
+      console.error("JSON parsing error:", e.message);
+      taskContext = {
+        tm: "30 minutes",
+        rem: "Check task details",
+      };
+    }
+
+    res.json({
+      original_task: task,
+      task_context: taskContext,
+      success: true,
+    });
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    console.error("Clarification error:", error);
+    res.status(500).json({
+      error: "Failed to clarify task",
+      details: error.message,
+    });
   }
 });
 


### PR DESCRIPTION
## Here's instructions how to test it locally:

make sure you have an `.env` file and load it like this (use your hugging face token):
```
HF_TOKEN="yourtoken"
PORT=5001
```

run the backend using `npm run dev`

open another terminal window and test it with curl like this:

```
curl -X POST http://localhost:5001/api/clarify \
  -H "Content-Type: application/json" \
  -d '{"task": "Write blog post"}' \
  | jq '.'
```

Your response shold be something like this:
<img width="619" height="249" alt="Screenshot 2025-10-18 at 10 47 22" src="https://github.com/user-attachments/assets/11ba06bf-619a-4927-8b8b-dcac60909d31" />

you can change the `value` on `-d` to test another prompt!
